### PR TITLE
fix: Update internal links to use index.php?page= structure

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -116,7 +116,7 @@ $admin_base_url = BASE_URL . 'admin/';
                                 <span class="text-gray-300">|</span>
                             </div>
                             
-                            <a href="<?php echo BASE_URL; ?>" target="_blank" class="btn-hover-effect text-sm text-admin-secondary hover:text-admin-secondary/80 flex items-center px-3 py-2 rounded-md">
+                            <a href="<?php echo BASE_URL; ?>index.php?page=home" target="_blank" class="btn-hover-effect text-sm text-admin-secondary hover:text-admin-secondary/80 flex items-center px-3 py-2 rounded-md">
                                 <i data-lucide="external-link" class="w-4 h-4 mr-1.5"></i>
                                 <span>View Site</span>
                             </a>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -21,26 +21,26 @@
                 <div>
                     <h5 class="text-base font-semibold text-text mb-4">Quick Links</h5>
                     <ul class="space-y-2 text-sm text-neutral-content">
-                        <li><a href="<?= rtrim(BASE_URL, '/'); ?>/" class="hover:text-secondary transition-colors">Home</a></li>
-                        <li><a href="<?= BASE_URL; ?>about" class="hover:text-secondary transition-colors">About Us</a></li>
-                        <li><a href="<?= BASE_URL; ?>services_overview" class="hover:text-secondary transition-colors">Services</a></li>
-                        <li><a href="<?= BASE_URL; ?>blog" class="hover:text-secondary transition-colors">Blog</a></li>
-                        <li><a href="<?= BASE_URL; ?>contact" class="hover:text-secondary transition-colors">Contact Us</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=home" class="hover:text-secondary transition-colors">Home</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=about" class="hover:text-secondary transition-colors">About Us</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=services_overview" class="hover:text-secondary transition-colors">Services</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=blog" class="hover:text-secondary transition-colors">Blog</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=contact" class="hover:text-secondary transition-colors">Contact Us</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-base font-semibold text-text mb-4">Our Services</h5>
                     <ul class="space-y-2 text-sm text-neutral-content">
-                        <li><a href="<?= BASE_URL; ?>webDev" class="hover:text-secondary transition-colors">Web Development</a></li>
-                        <li><a href="<?= BASE_URL; ?>software" class="hover:text-secondary transition-colors">Software Solutions</a></li>
-                        <li><a href="<?= BASE_URL; ?>cloud" class="hover:text-secondary transition-colors">Cloud &amp; DevOps</a></li>
-                        <li><a href="<?= BASE_URL; ?>cybersecurity" class="hover:text-secondary transition-colors">Cybersecurity</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=webDev" class="hover:text-secondary transition-colors">Web Development</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=software" class="hover:text-secondary transition-colors">Software Solutions</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=cloud" class="hover:text-secondary transition-colors">Cloud &amp; DevOps</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=cybersecurity" class="hover:text-secondary transition-colors">Cybersecurity</a></li>
                     </ul>
                 </div>
                 <div>
                     <h5 class="text-base font-semibold text-text mb-4">Legal</h5>
                     <ul class="space-y-2 text-sm text-neutral-content">
-                        <li><a href="<?= BASE_URL; ?>privacy" class="hover:text-secondary transition-colors">Privacy Policy</a></li>
+                        <li><a href="<?= BASE_URL; ?>index.php?page=privacy" class="hover:text-secondary transition-colors">Privacy Policy</a></li>
                         <li><a href="#" class="hover:text-secondary transition-colors">Terms of Service</a></li>
                     </ul>
                 </div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -157,9 +157,9 @@ $main_nav_links = [
   <div class="bg-neutral text-neutral-content/70 py-2 px-4 sm:px-6 lg:px-8 border-b border-neutral-light text-xs print:hidden">
     <div class="container mx-auto flex justify-between items-center">
       <div class="flex space-x-4">
-        <a href="<?= rtrim(BASE_URL, '/'); ?>/about"   class="hover:text-secondary transition-colors">About Us</a>
-        <a href="<?= rtrim(BASE_URL, '/'); ?>/contact" class="hover:text-secondary transition-colors">Contact</a>
-        <a href="<?= rtrim(BASE_URL, '/'); ?>/privacy" class="hover:text-secondary transition-colors">Privacy Policy</a>
+        <a href="<?= BASE_URL; ?>index.php?page=about"   class="hover:text-secondary transition-colors">About Us</a>
+        <a href="<?= BASE_URL; ?>index.php?page=contact" class="hover:text-secondary transition-colors">Contact</a>
+        <a href="<?= BASE_URL; ?>index.php?page=privacy" class="hover:text-secondary transition-colors">Privacy Policy</a>
       </div>
       <div class="flex space-x-3 items-center">
         <a href="#" aria-label="Facebook"  class="hover:text-secondary transition-colors"><i data-lucide="facebook"  class="w-4 h-4"></i></a>
@@ -178,7 +178,7 @@ $main_nav_links = [
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center h-16">
         <!-- Logo / Site Name -->
-        <a href="<?= rtrim(BASE_URL, '/'); ?>/" class="flex items-center space-x-2 shrink-0">
+        <a href="<?= BASE_URL; ?>index.php?page=home" class="flex items-center space-x-2 shrink-0">
           <i data-lucide="cpu" class="w-8 h-8 text-secondary"></i>
           <span class="font-display text-xl sm:text-2xl font-bold text-text hover:text-secondary transition-colors"><?= SITE_NAME; ?></span>
         </a>
@@ -186,7 +186,7 @@ $main_nav_links = [
         <!-- Desktop Menu -->
         <nav class="hidden md:flex items-center space-x-6">
           <?php foreach ($main_nav_links as $link_item): ?>
-            <?php $link_url = rtrim(BASE_URL, '/') . '/' . $link_item['page']; ?>
+            <?php $link_url = BASE_URL . 'index.php?page=' . $link_item['page']; ?>
             <?php $is_active = ($current_public_page === $link_item['page']); ?>
             <?php if (isset($link_item['is_mega_menu']) && $link_item['is_mega_menu']): ?>
               <div class="group relative">
@@ -200,7 +200,7 @@ $main_nav_links = [
                 <div class="mega-menu-container absolute top-full left-1/2 transform -translate-x-1/2 mt-0 w-max min-w-[560px] pt-1">
                   <div class="bg-neutral shadow-2xl rounded-b-lg border-t-2 border-secondary p-6 grid grid-cols-2 gap-x-6 gap-y-4">
                     <?php foreach ($services_menu_items_header as $s_item): ?>
-                      <a href="<?= rtrim(BASE_URL, '/') . '/' . $s_item['page']; ?>"
+                      <a href="<?= BASE_URL . 'index.php?page=' . $s_item['page']; ?>"
                          class="p-3 rounded-lg flex items-start space-x-3 transition-colors bg-neutral hover:bg-neutral-focus hover:text-white">
                         <i data-lucide="<?= $s_item['icon']; ?>" class="w-6 h-6 text-secondary mt-1"></i>
                         <div>
@@ -246,7 +246,7 @@ $main_nav_links = [
     <div id="mobileMenu" class="mobile-menu hidden bg-neutral border-t border-neutral-lighter/50 absolute w-full shadow-xl left-0">
       <nav class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
         <?php foreach ($main_nav_links as $link_item): ?>
-          <?php $link_url_mobile = rtrim(BASE_URL, '/') . '/' . $link_item['page']; ?>
+          <?php $link_url_mobile = BASE_URL . 'index.php?page=' . $link_item['page']; ?>
           <?php $is_active_mobile = ($current_public_page === $link_item['page']); ?>
           <a href="<?= $link_url_mobile; ?>"
              class="block px-3 py-3 rounded-md text-base font-medium <?= $is_active_mobile ? 'text-secondary bg-neutral-focus' : 'text-text/80 hover:bg-neutral-focus hover:text-white'; ?> transition-colors flex items-center space-x-2">
@@ -256,7 +256,7 @@ $main_nav_links = [
           <?php if (isset($link_item['is_mega_menu']) && $link_item['is_mega_menu']): ?>
             <div class="pl-5 space-y-1 border-l-2 border-neutral-focus ml-2.5 mb-2">
               <?php foreach ($services_menu_items_header as $s_item): ?>
-                <a href="<?= rtrim(BASE_URL, '/') . '/' . $s_item['page']; ?>"
+                <a href="<?= BASE_URL . 'index.php?page=' . $s_item['page']; ?>"
                    class="block px-3 py-2 rounded-md text-sm font-medium text-text/80 hover:bg-neutral-focus hover:text-white transition-colors flex items-center space-x-2">
                   <i data-lucide="<?= $s_item['icon']; ?>" class="w-4 h-4"></i>
                   <span><?= esc_html($s_item['name']); ?></span>

--- a/pages/blog.php
+++ b/pages/blog.php
@@ -116,7 +116,8 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
     <!-- Filter Section -->
     <div class="mb-10 p-6 bg-base-100 rounded-lg shadow-md">
       <h3 class="text-xl font-semibold text-text mb-4">Filter Posts</h3>
-      <form method="GET" action="<?= rtrim(BASE_URL, '/'); ?>/blog" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 items-end">
+      <form method="GET" action="<?= BASE_URL; ?>index.php?page=blog" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 items-end">
+        <input type="hidden" name="page" value="blog"> <!-- Keep page parameter for form submission -->
         <div>
           <label for="search" class="block text-sm font-medium text-text/70 mb-1">Search</label>
           <input
@@ -154,7 +155,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
           </button>
           <?php if ($search_term || $category_filter_slug): ?>
             <a
-              href="<?= rtrim(BASE_URL, '/'); ?>/blog"
+              href="<?= BASE_URL; ?>index.php?page=blog"
               class="block mt-2 sm:mt-0 sm:ml-2 text-xs text-text/70 hover:text-secondary underline"
             >Clear Filters</a>
           <?php endif; ?>
@@ -169,7 +170,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
             class="bg-base-100 rounded-xl shadow-xl overflow-hidden flex flex-col transition-all duration-300 hover:shadow-secondary/20 hover:-translate-y-1 animate-fade-in-up"
             style="animation-delay: <?= $idx * 100; ?>ms"
           >
-            <?php $post_url = rtrim(BASE_URL, '/') . '/' . esc_html($post['slug']); ?>
+            <?php $post_url = BASE_URL . 'index.php?page=post&slug=' . esc_html($post['slug']); ?>
             <?php if (!empty($post['featured_image'])): ?>
               <a href="<?= $post_url; ?>">
                 <img
@@ -188,7 +189,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
             <div class="p-6 flex flex-col flex-grow">
               <div class="mb-3 flex items-center space-x-2">
                 <?php if (!empty($post['category_name'])):
-                  $category_url = rtrim(BASE_URL, '/') . '/blog/category/' . esc_html($post['category_slug']);
+                  $category_url = BASE_URL . 'index.php?page=blog&category=' . esc_html($post['category_slug']);
                 ?>
                   <a
                     href="<?= $category_url; ?>"
@@ -220,16 +221,28 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
       </div>
 
       <?php if ($total_pages > 1):
-        $base_url = rtrim(BASE_URL, '/') . '/blog';
+        // Construct the base link for pagination using index.php?page= format
+        $pagination_params = ['page' => 'blog'];
         if ($category_filter_slug) {
-          $base_url .= '/category/' . urlencode($category_filter_slug);
+            $pagination_params['category'] = $category_filter_slug;
         }
-        $search_query = $search_term ? '?search=' . urlencode($search_term) : '';
+        if ($search_term) {
+            $pagination_params['search'] = $search_term;
+        }
+
+        // Function to generate pagination link
+        function generate_blog_pagination_link($page_num, $base_params) {
+            $current_params = $base_params;
+            if ($page_num > 1) {
+                $current_params['paged'] = $page_num;
+            }
+            return BASE_URL . 'index.php?' . http_build_query($current_params);
+        }
       ?>
         <nav class="mt-12 md:mt-16 pt-8 border-t border-neutral-light flex justify-center items-center space-x-1 sm:space-x-2" aria-label="Pagination">
           <?php if ($current_page_number > 1): ?>
             <a
-              href="<?= $base_url . '/page/' . ($current_page_number - 1) . $search_query; ?>"
+              href="<?= generate_blog_pagination_link($current_page_number - 1, $pagination_params); ?>"
               class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors flex items-center"
             ><i data-lucide="chevron-left" class="w-4 h-4 sm:mr-1"></i><span class="hidden sm:inline">Previous</span></a>
           <?php endif; ?>
@@ -243,7 +256,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
             }
 
             if ($start > 1) {
-              echo '<a href="'.$base_url.'/page/1'.$search_query.'" class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors">1</a>';
+              echo '<a href="'.generate_blog_pagination_link(1, $pagination_params).'" class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors">1</a>';
               if ($start > 2) {
                 echo '<span class="px-3 py-2 sm:px-4 text-sm text-text/60">...</span>';
               }
@@ -255,7 +268,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
               <span aria-current="page" class="px-3 py-2 sm:px-4 text-sm font-semibold text-white bg-secondary rounded-md"><?= $i; ?></span>
             <?php else: ?>
               <a
-                href="<?= $base_url . '/page/' . $i . $search_query; ?>"
+                href="<?= generate_blog_pagination_link($i, $pagination_params); ?>"
                 class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors"
               ><?= $i; ?></a>
             <?php endif; ?>
@@ -265,13 +278,13 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
               if ($end < $total_pages - 1) {
                 echo '<span class="px-3 py-2 sm:px-4 text-sm text-text/60">...</span>';
               }
-              echo '<a href="'.$base_url.'/page/'.$total_pages.$search_query.'" class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors">'.$total_pages.'</a>';
+              echo '<a href="'.generate_blog_pagination_link($total_pages, $pagination_params).'" class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors">'.$total_pages.'</a>';
             }
           ?>
 
           <?php if ($current_page_number < $total_pages): ?>
             <a
-              href="<?= $base_url . '/page/' . ($current_page_number + 1) . $search_query; ?>"
+              href="<?= generate_blog_pagination_link($current_page_number + 1, $pagination_params); ?>"
               class="px-3 py-2 sm:px-4 text-sm text-text/80 bg-base-200 hover:bg-secondary hover:text-white rounded-md transition-colors flex items-center"
             ><span class="hidden sm:inline">Next</span> <i data-lucide="chevron-right" class="w-4 h-4 sm:ml-1"></i></a>
           <?php endif; ?>
@@ -285,7 +298,7 @@ $all_categories        = ($all_categories_result && $all_categories_result->num_
         <p class="text-text/60">It seems there are no blog posts matching your criteria. Try adjusting your filters or check back later!</p>
         <?php if ($search_term || $category_filter_slug): ?>
           <a
-            href="<?= rtrim(BASE_URL, '/'); ?>/blog"
+            href="<?= BASE_URL; ?>index.php?page=blog"
             class="mt-6 inline-flex items-center px-5 py-3 bg-secondary hover:bg-secondary-hover text-white font-medium rounded-lg shadow transition-colors"
           >Clear Filters and Show All Posts</a>
         <?php endif; ?>

--- a/pages/post.php
+++ b/pages/post.php
@@ -8,7 +8,7 @@ global $site_settings;
 
 $post_data = null;
 $is_preview = false;
-$base_blog_url_for_return = rtrim(BASE_URL, '/') . '/blog';
+$base_blog_url_for_return = BASE_URL . 'index.php?page=blog'; // Changed to index.php?page= format
 
 if (isset($_GET['preview_id'], $_GET['token']) && isset($_SESSION['admin_user_id'])) {
     $preview_post_id = (int)$_GET['preview_id'];
@@ -135,7 +135,8 @@ if ($post_data && !empty($post_data['slug'])) {
       <article class="bg-base-100 p-6 sm:p-8 md:p-10 rounded-xl shadow-2xl">
         <header class="mb-8 pb-6 border-b border-base-200">
           <?php if (!empty($post_data['category_name']) && !empty($post_data['category_slug'])):
-            $category_url = rtrim(BASE_URL, '/') . '/blog/category/' . esc_html($post_data['category_slug']);
+            // Assuming blog.php handles a 'category' GET parameter for filtering
+            $category_url = BASE_URL . 'index.php?page=blog&category=' . esc_html($post_data['category_slug']);
           ?>
             <a href="<?= $category_url; ?>"
                class="text-sm font-semibold uppercase tracking-wider text-secondary hover:text-highlight transition-colors"


### PR DESCRIPTION
- Modified link generation in public header, footer, admin header ('View Site' link), post page, and blog page (including pagination and filters).
- All navigational links now explicitly use `index.php?page={page_name}&param=value` format.
- This change is to ensure site functionality in environments where clean URL rewriting might not be active (e.g., no .htaccess file).